### PR TITLE
gtest, gmock and benchmark package provider change

### DIFF
--- a/.conan/conanfile.txt
+++ b/.conan/conanfile.txt
@@ -1,0 +1,3 @@
+[requires]
+gtest/1.10.0
+benchmark/1.5.2

--- a/.conan/profile_gcc_debug
+++ b/.conan/profile_gcc_debug
@@ -1,0 +1,16 @@
+[settings]
+os=Linux
+os_build=Linux
+os_target=Linux
+arch=x86_64
+arch_build=x86_64
+arch_target=x86_64
+compiler=gcc
+compiler.version=10
+compiler.libcxx=libstdc++11
+build_type=Debug
+cppstd=20
+
+[env]
+CC=/usr/bin/gcc-10
+CXX=/usr/bin/g++-10

--- a/.conan/profile_gcc_relwithdbginfo
+++ b/.conan/profile_gcc_relwithdbginfo
@@ -1,0 +1,16 @@
+[settings]
+os=Linux
+os_build=Linux
+os_target=Linux
+arch=x86_64
+arch_build=x86_64
+arch_target=x86_64
+compiler=gcc
+compiler.version=10
+compiler.libcxx=libstdc++11
+build_type=RelWithDebInfo
+cppstd=20
+
+[env]
+CC=/usr/bin/gcc-10
+CXX=/usr/bin/g++-10

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 COPY bootstrap.sh /scripts/
+COPY .conan/ /scripts/.conan
 
 # Configure apt and install packages
 RUN chmod +x /scripts/bootstrap.sh
@@ -37,3 +38,6 @@ RUN /scripts/bootstrap.sh
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog
+
+# Switch to non-root user
+USER $USER_UID

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ image: nettsi/hadouken:latest
 | :-----------------: | :---------------------------------------------------: | :-----------: | :----------: |
 |         git         |  fast, scalable, distributed revision control system  | >= 1:2.26.2-1 |   >= v1.0    |
 |      git-flow       | Git extension to provide a high-level branching model |  >= 1.12.3-1  |   >= v1.0    |
+|      git-lfs        | Git extension to large file storage support |  >= 2.12.0 |   >= v1.0    |
 
 ### Script Interpreters
 
@@ -102,11 +103,10 @@ image: nettsi/hadouken:latest
 
 ### Unit testing/mocking/benchmarking
 
-| Debian package name |                    Description                    |   Version   | Available in |
+| Conan package name |                    Description                    |   Version   | Available in |
 | :-----------------: | :-----------------------------------------------: | :---------: | :----------: |
-|    libgtest-dev     |   Google's framework for writing C++ unit tests   | >= 1.10.0-3 |   >= v1.0    |
-|    libgmock-dev     |   Google's framework for writing C++ mock code    | >= 1.10.0-3 |   >= v1.0    |
-|  libbenchmark-dev   | Microbenchmark support library, development files | >= 1.5.0-4  |   >= v1.0    |
+|    gtest     |   Google's framework for writing C++ unit tests (also provides gmock)   | >= 1.10.0 |   >= v2.0    |
+|    benchmark     |   Microbenchmark support library, development files     | >= 1.5.2  |   >= v2.0    |
 
 ### Code coverage analysis
 
@@ -120,7 +120,6 @@ image: nettsi/hadouken:latest
 | Debian package name |                         Description                          |   Version   | Available in |
 | :-----------------: | :----------------------------------------------------------: | :---------: | :----------: |
 |       doxygen       | Documentation system for C, C++, Java, Python and other languages | >= 1.8.17-1 |   >= v1.0    |
-|    doxygen-latex    |  Adds latex format support for doxygen document generation   | >= 1.8.17-1 |   >= v1.0    |
 |  doxygen-doxyparse  |      multi-language source code parser based on Doxygen      | >= 1.8.17-1 |   >= v1.0    |
 |      graphviz       |               rich set of graph drawing tools                | >= 2.42.2-4 |   >= v1.0    |
 


### PR DESCRIPTION
Gtest, gmock and benchmark are now satisfied via conan dependencies instead of debian.